### PR TITLE
The d3js.org source link is broken

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
         <div class="row-fluid">
           <span class="span12">
             <h1 class="heading">Charts. Better. <a href="https://github.com/angular-d3/line-chart" class="btn btn-large btn-success"><i class="icon-github icon-white"></i> Download</a></h1>
-            <p>Awesome charts for <a href="http://angularjs.org/">AngularJS</a>, powered by <a href="d3js.org">D3.js</a>.</p>
+            <p>Awesome charts for <a href="http://angularjs.org/">AngularJS</a>, powered by <a href="http://d3js.org">D3.js</a>.</p>
             <div class='carousel mainchart'>
               <linechart data='examples[currentIndex].data'options='examples[currentIndex].options'></linechart>
               <a class="left carousel-control" ng-click='previous()'>‹</a>


### PR DESCRIPTION
The current link to d3js.org is broken, the http procool is missing. :)
