### PR TITLE
no longer pushes invalid data into seriesData

### DIFF
--- a/lib/utils/misc.js
+++ b/lib/utils/misc.js
@@ -74,11 +74,13 @@ getDataPerSeries: function(data, options) {
     };
 
     data.forEach(function(row) {
-      seriesData.values.push({
-        x: row[options.axes.x.key],
-        value: row[s.y],
-        axis: s.axis || 'y'
-      });
+      if(typeof row[s.y] != 'undefined') {
+        seriesData.values.push({
+          x: row[options.axes.x.key],
+          value: row[s.y],
+          axis: s.axis || 'y'
+        });
+      }
     });
 
     straightenedData.push(seriesData);


### PR DESCRIPTION
in the case where one (or more) data series is missing data, line-chart would fail to complete or in some cases entirely fail to chart the corresponding line.

The problem is that in the case of a "sparse" set of data, line-chart would send "undefined" data into D3 which would cause problems.

The following patch fixes the problem.  I notice that the code base is very "functional" in style, so perhaps there is a cleaner way to do this, I'm not an expert at it.

Here is some code which will cause the problem, it's a variation on one of the plunker examples.

```
var app = angular.module('plunker', ['n3-charts.linechart']);

app.controller('MainCtrl', function($scope) {
  $scope.data = [
    {x: 0, other: 3},
    {x: 1, value: 4, other:4},
    {x: 2, value: 7, other: 5},
    {x: 2.5, value: 6.5, other: 5},
    {x: 3, value: 0}];

  // Line
  $scope.options = {series: [{y: 'value', color: 'steelblue'},{y:'other',color:'green'}]};

});
```
