### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,9 @@
   "dependencies": {
     "d3": "*",
     "angular": "*",
-    "angular-mocks": "*",
     "moment": "*"
+  },
+  "devDependencies": {
+    "angular-mocks": "*"
   }
 }


### PR DESCRIPTION
angular-mocks should be a dev dependency, when it's not it is a problem when using grunt wiredep
