### PR TITLE
Update line-chart.js

### DIFF
--- a/build/line-chart.js
+++ b/build/line-chart.js
@@ -845,7 +845,7 @@ mod.factory('n3utils', [
         return bbox;
       },
       getTextBBox: function(svgTextElement) {
-        return svgTextElement.getBBox();
+        return svgTextElement != null ? svgTextElement.getBBox() : {};
       },
       getWidestTickWidth: function(svg, axisKey) {
         var bbox, max, ticks, _ref;


### PR DESCRIPTION
to handle exception thrown when tooltip mode is chosen to be "NONE" and mouse is hovered over the svg elements.