### PR TITLE
Improve testing instructions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ before_install:
 - export DISPLAY=:99.0
 - sh -e /etc/init.d/xvfb start
 - npm install
-- bower install
 - sudo pip install pillow
 script: grunt travis
 addons:

--- a/README.md
+++ b/README.md
@@ -222,11 +222,6 @@ Install dev dependencies :
 $ npm install
 ```
 
-Install components :
-```sh
-$ bower install
-```
-
 Watch :
 ```sh
 $ grunt watch
@@ -239,6 +234,7 @@ $ grunt
 
 Or run the visual tests, too :
 ```sh
+$ pip install pillow
 $ grunt travis
 ```
 

--- a/package.json
+++ b/package.json
@@ -39,5 +39,9 @@
     "matchdep": "*",
     "phantomjs": "~1.9.7-5",
     "sinon": "~1.9.1"
+  },
+  "scripts": {
+    "postinstall": "bower install",
+    "test": "grunt"
   }
 }


### PR DESCRIPTION
- Automatically `bower install` after `npm install`.
- Allow using `npm test` blindly.
- Document installation of `pillow` for visual tests.