### PR TITLE
Ignore invisible folders in visual tests

### DIFF
--- a/test/visual/scripts/run.py
+++ b/test/visual/scripts/run.py
@@ -52,7 +52,7 @@ def error(message):
 
 def debug(message):
   if verbose:
-    print message
+    print "[DBUG] " + message
 
 def warn(message):
   print bcolors.WARNING + message + bcolors.ENDC
@@ -72,7 +72,8 @@ def sanitize_test_cases():
     dirs = []
 
     for test in tests:
-      if test == '.tmp':
+      if test.startswith('.'):
+        debug("Ignoring invisible folder '" + test + "'.")
         continue
 
       if sanitize_test_case(test):


### PR DESCRIPTION
If there is, for example, a `.DS_Store` in the `visual_tests` directory, `run.py` won't start, complaining that:

```
[WARN] .DS_Store does not contain 'desc' file.
[WARN] .DS_Store does not contain 'expected.png' image.
Testcase '.DS_Store' is missing the following files : html, options, data
```

This PR fixes this by generalising ignores from `.tmp` to all `.`-prefixed folders.

It also improves debug logging.