### PR TITLE
Do not attach scroll listeners when `zoomable` is not set

### DIFF
--- a/src/utils/events.coffee
+++ b/src/utils/events.coffee
@@ -1,5 +1,5 @@
       getEventDispatcher: () ->
-        
+
         events = [
           'focus',
           'hover',
@@ -13,61 +13,40 @@
         zoom.scale(1)
         zoom.translate([0, 0])
 
-        if options.axes.x.zoomable?
-          svg.selectAll('.x.axis').call(axes.xAxis)
+        this.getZoomHandler(svg, dimensions, axes, data, columnWidth, options, handlers, dispatch, false)()
 
-        if options.axes.y.zoomable?
-          svg.selectAll('.y.axis').call(axes.yAxis)
+      getZoomHandler: (svg, dimensions, axes, data, columnWidth, options, handlers, dispatch, zoom) ->
+        self = this
 
-        if options.axes.y2?.zoomable?
-          svg.selectAll('.y2.axis').call(axes.y2Axis)
+        return ->
+          zoomed = false
 
-        if data.length
-          columnWidth = this.getBestColumnWidth(axes, dimensions, data, options)
-          this.drawData(svg, dimensions, axes, data, columnWidth, options, handlers, dispatch)
+          [ 'x', 'y', 'y2' ].forEach (axis) ->
+            if options.axes[axis]?.zoomable?
+              svg.selectAll(".#{axis}.axis").call(axes["#{axis}Axis"])
+              zoomed = true
+
+          if data.length
+            columnWidth = self.getBestColumnWidth(axes, dimensions, data, options)
+            self.drawData(svg, dimensions, axes, data, columnWidth, options, handlers, dispatch)
+
+          if zoom and zoomed
+            self.createZoomResetIcon(svg, dimensions, axes, data, columnWidth, options, handlers, dispatch, zoom)
 
       setZoom: (svg, dimensions, axes, data, columnWidth, options, handlers, dispatch) ->
-        self = this
-        
-        zoomHandler = () ->
-            zoomed = false
+        zoom = this.getZoomListener(axes, options)
 
-            if options.axes.x.zoomable?
-              svg.selectAll('.x.axis').call(axes.xAxis)
-              zoomed = true
+        if zoom
+          zoom.on("zoom", this.getZoomHandler(svg, dimensions, axes, data, columnWidth, options, handlers, dispatch, zoom))
+          svg.call(zoom)
 
-            if options.axes.y.zoomable?
-              svg.selectAll('.y.axis').call(axes.yAxis)
-              zoomed = true
+      getZoomListener: (axes, options) ->
+        zoomable = false
+        zoom = d3.behavior.zoom()
 
-            if options.axes.y2?.zoomable?
-              svg.selectAll('.y2.axis').call(axes.y2Axis)
-              zoomed = true
+        [ 'x', 'y', 'y2' ].forEach (axis) ->
+          if options.axes[axis]?.zoomable?
+            zoom[axis](axes["#{axis}Scale"])
+            zoomable = true
 
-            if data.length
-              columnWidth = self.getBestColumnWidth(axes, dimensions, data, options)
-              self.drawData(svg, dimensions, axes, data, columnWidth, options, handlers, dispatch)
-
-            if zoomed
-              self.createZoomResetIcon(svg, dimensions, axes, data, columnWidth, options, handlers, dispatch, zoom)
-
-        zoom = this.getZoomListener(axes, options, zoomHandler)
-        svg.call(zoom)
-
-      getZoomListener: (axes, options, zoomHandler) ->
-
-        zoomListener = d3.behavior.zoom()
-
-        if zoomHandler?
-          zoomListener.on("zoom", zoomHandler)
-
-        if options.axes.x?.zoomable?
-          zoomListener.x(axes.xScale)
-
-        if options.axes.y?.zoomable?
-          zoomListener.y(axes.yScale)
-        
-        if options.axes.y2?.zoomable?
-          zoomListener.y(axes.y2Scale)
-
-        return zoomListener
+        return if zoomable then zoom else false

--- a/src/utils/events.coffee
+++ b/src/utils/events.coffee
@@ -45,7 +45,7 @@
         zoom = d3.behavior.zoom()
 
         [ 'x', 'y', 'y2' ].forEach (axis) ->
-          if options.axes[axis]?.zoomable?
+          if options.axes[axis]?.zoomable
             zoom[axis](axes["#{axis}Scale"])
             zoomable = true
 

--- a/test/unit/events.mocha.coffee
+++ b/test/unit/events.mocha.coffee
@@ -264,7 +264,7 @@ describe 'event handling', ->
 
       glass = element.childByClass('glass').domElement
       fakeMouse.wheel(glass, 0, -10)
-      
+
       columnGroup = element.childByClass('columnGroup')
       expect(columnGroup.children()[0].getAttribute('x')).to.equal('130')
       expect(columnGroup.children()[0].getAttribute('y')).to.equal('456')
@@ -292,9 +292,34 @@ describe 'event handling', ->
 
       glass = element.childByClass('glass').domElement
       fakeMouse.wheel(glass, 0, -10)
-      
+
       columnGroup = element.childByClass('columnGroup')
       expect(columnGroup.children()[0].getAttribute('x')).to.equal('130')
       expect(columnGroup.children()[0].getAttribute('y')).to.equal('462')
       expect(columnGroup.children()[0].getAttribute('width')).to.equal('125')
       expect(columnGroup.children()[0].getAttribute('height')).to.equal('38')
+
+    it 'should ignore zoom events by default', ->
+
+      getColumn = -> element.childByClass('columnGroup').children()[0]
+
+      outerScope.$apply ->
+        outerScope.options =
+          margin:
+            {left: 0, bottom: 0, top: 0, right: 0}
+          axes:
+            x: {zoomable: false}
+            y: {zoomable: false}
+          series: [
+            {y: 'value', type: 'column'}
+          ]
+
+      originalPosition =
+        x: getColumn().getAttribute('x')
+        y: getColumn().getAttribute('y')
+
+      glass = element.childByClass('glass').domElement
+      fakeMouse.wheel(glass, 0, -10)
+
+      expect(getColumn().getAttribute('x')).to.equal(originalPosition.x)
+      expect(getColumn().getAttribute('y')).to.equal(originalPosition.y)


### PR DESCRIPTION
Currently, scroll events are swallowed while your cursor is over a chart, which prevents you from continuously scrolling down a page that has embedded charts. This PR prevents attaching scroll listeners (via `d3.behavior.zoom()`) unless one or more axes has the `zoomable: true` option set. I also removed some duplicate logic and cleaned up a couple things.

This wasn't possible to unit test since it requires validating the window scroll position. I also didn't see a way to manipulate the page programmatically in the visual tests. I'm happy to add some if we can find a way that will work with your existing suite, though!