### PR TITLE
Only detach the resize callback of the current chart

### DIFF
--- a/src/LineChart.ts
+++ b/src/LineChart.ts
@@ -158,7 +158,7 @@ module n3Charts {
       // Trigger the destroy event
       scope.$on('$destroy', () => {
         eventMgr.trigger('destroy');
-        angular.element(this.$window).off();
+        angular.element(this.$window).off('resize', resizeCb);
       });
     };
   }


### PR DESCRIPTION
Currently if a scope is destroyed, the call `$window.off()` removes _all_ listeners, even external listeners. With this commit this is fixed and only the previously attached resize callback is being removed when a $destroy event has been fired.