### PR TITLE
Fix negative value error

### DIFF
--- a/src/factories/Container.ts
+++ b/src/factories/Container.ts
@@ -142,7 +142,7 @@ module n3Charts.Factory {
 
       d3.select(this.element).select('#clipping-rect')
         .attr({
-          'width': this.dim.innerWidth,
+          'width': Math.max(this.dim.innerWidth, 0),
           'height': Math.max(this.dim.innerHeight, 0)
         });
     }


### PR DESCRIPTION
When using tabs module and table hidden in Chrome console there is error: Invalid negative value for <rect> attribute width="-80".