### PR TITLE
add option to control whether graph data is deep-watched by Angular

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -208,6 +208,18 @@ Name | Type | Default | Description | Mandatory
 ---- | ---- | ------- | ------------ | --------
 `doubleClickEnabled` | Boolean | `true` | Enables/disables the double click handling | No
 
+### Deep watch
+In AngularJS, by default, the chart deep-watches `data` for changes.  To use a faster reference watch instead, set the `deepWatchData` parameter.
+
+```js
+deepWatchData: false
+```
+
+Name | Type | Default | Description | Mandatory
+---- | ---- | ------- | ------------ | --------
+`deepWatchData` | Boolean | `true` | Enables/disables deep watch in AngularJS | No
+
+
 ## Synchronization and callbacks
 
 The directive accepts additional HTML attributes to allow charts' synchronization and callbacks on various events.

--- a/src/angularjs/LineChart.ts
+++ b/src/angularjs/LineChart.ts
@@ -105,7 +105,7 @@ module n3Charts {
       };
 
       scope.$watch('options', updateAll, true);
-      scope.$watch('data', updateData, scope.options.deepWatchData);
+      scope.$watch('data', updateData, options ? options.deepWatchData : true);
 
       eventMgr.on('legend-click.directive', (series) => {
         var foundSeries = scope.options.series.filter((s) => s.id === series.id)[0];

--- a/src/angularjs/LineChart.ts
+++ b/src/angularjs/LineChart.ts
@@ -40,7 +40,7 @@ module n3Charts {
 
     link = (scope: ILineChartScope, element: JQuery, attributes: any) => {
       var data:Utils.Data;
-      var options:Options.Options;
+      var options = new Options.Options();
       var eventMgr = new Utils.EventManager();
       var factoryMgr = new Utils.FactoryManager();
 
@@ -105,7 +105,7 @@ module n3Charts {
       };
 
       scope.$watch('options', updateAll, true);
-      scope.$watch('data', updateData, options ? options.deepWatchData : true);
+      scope.$watch('data', updateData, options.deepWatchData);
 
       eventMgr.on('legend-click.directive', (series) => {
         var foundSeries = scope.options.series.filter((s) => s.id === series.id)[0];

--- a/src/angularjs/LineChart.ts
+++ b/src/angularjs/LineChart.ts
@@ -105,7 +105,7 @@ module n3Charts {
       };
 
       scope.$watch('options', updateAll, true);
-      scope.$watch('data', updateData, true);
+      scope.$watch('data', updateData, scope.options.deepWatchData);
 
       eventMgr.on('legend-click.directive', (series) => {
         var foundSeries = scope.options.series.filter((s) => s.id === series.id)[0];

--- a/src/options/Options.ts
+++ b/src/options/Options.ts
@@ -21,6 +21,8 @@ module n3Charts.Options {
 
   export class Options {
 
+    public deepWatchData: Boolean = true;
+
     public doubleClickEnabled = true;
 
     public tooltipHook: Function;
@@ -65,6 +67,7 @@ module n3Charts.Options {
       this.zoom = this.sanitizeTwoAxesOptions(options.zoom, this.zoom);
       this.tooltipHook = Options.getFunction(options.tooltipHook);
       this.doubleClickEnabled = Options.getBoolean(options.doubleClickEnabled, false);
+      this.deepWatchData = Options.getBoolean(options.deepWatchData, true);
     }
 
     sanitizeMargin(margin: any): IMargin {


### PR DESCRIPTION
Hi guys, 
I haven't filed an issue for this, but I'm having performance problems sometimes because of the deep watch on the data.  When there's a lot of data in the charts -- tens of thousands of points -- it takes significant time for Angular to inspect it every digest cycle, even when it isn't changing.  I've added an optional attribute to `options` to make the watch on `data` shallow.  Please LMK what you think.
