### PR TITLE
Make y2 axis shown only when y2 is used

### DIFF
--- a/src/factories/Axis.ts
+++ b/src/factories/Axis.ts
@@ -148,7 +148,7 @@ module n3Charts.Factory {
         let series = options.getVisibleSeriesBySide(this.side);
 
         if (this.side === Options.AxisOptions.SIDE.Y2 && series.length === 0) {
-          series = options.getVisibleSeriesBySide(Options.AxisOptions.SIDE.Y);
+          series = options.getVisibleSeriesBySide(Options.AxisOptions.SIDE.Y2);
         }
 
         series.forEach(s => {


### PR DESCRIPTION
Hi! I was getting the y2 axis displayed in situations where it was not being specified in any series, and the y parameter of the axes object is being modified.  I believe this is a bug and not the intent, but if it is please disregard this.  If you take a look at the ["y0 - y1" example](http://n3-charts.github.io/line-chart/#/examples) you will see that the y2 axis is drawn, but no series targets it.  If "axes: y: {something}" is defined, then you will get both y and y2 being drawn.  This change corrects this.  Thanks!
