### PR TITLE
Used relativ node dependencies in scripts

### DIFF
--- a/scripts/compile
+++ b/scripts/compile
@@ -1,6 +1,9 @@
 #! /usr/bin/env bash
 
-tsc
+# Stop the script if an operation fails
+set -e
+
+node_modules/typescript/bin/tsc
 
 FILES=`ls src`
 

--- a/scripts/compile
+++ b/scripts/compile
@@ -6,15 +6,15 @@ FILES=`ls src`
 
 ./scripts/sass
 
-webpack --display-error-details
+node_modules/webpack/bin/webpack.js --display-error-details
 
 # For backward comp
 mv build/build/LineChart-angularjs.js build/build/LineChart.js
 
 mv build/react/LineChart.d.ts build/build/LineChart-react.d.ts
 
-uglifyjs build/build/LineChart.js > build/build/LineChart.min.js
-uglifyjs build/build/LineChart-react.js > build/build/LineChart-react.min.js
+node_modules/uglify-js/bin/uglifyjs build/build/LineChart.js > build/build/LineChart.min.js
+node_modules/uglify-js/bin/uglifyjs build/build/LineChart-react.js > build/build/LineChart-react.min.js
 
 (cd build && rm -rf ${FILES})
 mv build/build/ tmp && rm -rf build && mv tmp build

--- a/scripts/e2e-test
+++ b/scripts/e2e-test
@@ -13,7 +13,7 @@ const runTests = () => {
   const deferred = Q.defer();
 
   glob('e2e/tests/*.e2e.js', (er, files) => {
-    let child = exec('protractor --specs ' + files.join(',') + ' config/protractor.conf.js');
+    let child = exec('node_modules/protractor/bin/protractor --specs ' + files.join(',') + ' config/protractor.conf.js');
 
     child.stdout.pipe(process.stdout);
     child.stderr.pipe(process.stderr);

--- a/scripts/serve
+++ b/scripts/serve
@@ -6,8 +6,11 @@ const Q = require('q');
 const supportedProjects = require('./supported-projects');
 
 const serve = function(project, port) {
-  if (supportedProjects.indexOf(project) === -1) throw new Error('Unsupported project : ' + project);
-
+  if (supportedProjects.indexOf(project) === -1) {
+    console.error('Usage: ./scripts/serve <project> <port>\n  project: `angularjs` or `react`');
+    throw new Error('Unsupported project. Choose either `angularjs` or `react`');
+  }
+  
   port = port || 1234;
 
   const app = express();

--- a/scripts/unit-test
+++ b/scripts/unit-test
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 
-tsc --outDir .tmp/unit-tests
+node_modules/typescript/bin/tsc --outDir .tmp/unit-tests
 
-mocha -r jsdom-global/register .tmp/unit-tests/**/*.spec.js
+node_modules/mocha/bin/mocha -r jsdom-global/register .tmp/unit-tests/**/*.spec.js
 
 rm -rf .tmp/unit-tests

--- a/scripts/unit-test
+++ b/scripts/unit-test
@@ -1,5 +1,8 @@
 #! /usr/bin/env bash
 
+# Stop the script if an operation fails
+set -e
+
 node_modules/typescript/bin/tsc --outDir .tmp/unit-tests
 
 node_modules/mocha/bin/mocha -r jsdom-global/register .tmp/unit-tests/**/*.spec.js


### PR DESCRIPTION
I updated the scripts to use relative paths. Like this running `npm install` sets up the complete work environment properly (without dealing with -g).